### PR TITLE
Fix SDK importJson README example

### DIFF
--- a/packages/javascript-sdk/CONTRIBUTING.md
+++ b/packages/javascript-sdk/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing
 
 ---
+
 We need to keep every import with preserved `.js` extension.
 
 Explicitly including the `.js` extension in ESM imports ensures that modules are correctly resolved in Node.js and browser
@@ -8,10 +9,10 @@ environments, complies with the ECMAScript module specification, and maintains c
 different tools and platforms.
 
 Here is regexp to match broken imports:
+
 ```bash
 import\s+[^'"\n]*\s*['"][^'"\n]*(?<!\.js)['"]
 ```
-
 
 ### Adding new changesets
 
@@ -23,4 +24,3 @@ To generate a new changeset, run `pnpm changeset` in the root of the repository.
 2. Run `pnpm i`. This will update the lockfile and rebuild packages.
    Commit the changes.
 3. Run `pnpm run publish`. This command will publish all packages that have bumped versions not yet present in the registry.
-

--- a/packages/javascript-sdk/README.md
+++ b/packages/javascript-sdk/README.md
@@ -88,7 +88,7 @@ const memories = await db.ai.search({
 // Push nested JSON — relationships created automatically
 await db.records.importJson({
   label: 'COMPANY',
-  payload: {
+  data: {
     name: 'Acme Corp',
     DEPARTMENT: [
       {


### PR DESCRIPTION
## Summary
- use the supported `data` option in the JavaScript SDK `importJson` README example
- fix the misspelled SDK contributing filename

## Checks
- `pnpm exec prettier --check packages/javascript-sdk/README.md packages/javascript-sdk/CONTRIBUTING.md`
- pre-commit hook: typecheck and core Jest suite